### PR TITLE
Fix Rscript displays initial messages.

### DIFF
--- a/setup-MRO/packageFiles/etc/Rprofile.site
+++ b/setup-MRO/packageFiles/etc/Rprofile.site
@@ -115,7 +115,7 @@ local(
 		MKLmsg <- ""
 	}
 	
-	quiet <- any(match(c("-q", "--silent", "--quiet", "--slave"), commandArgs()), na.rm=TRUE)
+	quiet <- any(match(c("-q", "--silent", "--quiet", "--slave", "-no-echo"), commandArgs()), na.rm=TRUE)
 	if (!quiet && !identical(system.file(package="RevoScaleR") , "")) {
         cat("Microsoft R Open ",R.version$major,".",R.version$minor,"\n",sep="")
         cat("The enhanced R distribution from Microsoft\n",sep="")


### PR DESCRIPTION
In R, the "--slave" option has been changed to the "--no-echo" option, so in MRO 4.0.2, Rscript will display the initial message.

https://stat.ethz.ch/pipermail/r-help/2019-September/464281.html

The following bugs have been fixed.

```
[vagrant@localhost ropen]$ /opt/microsoft/ropen/3.5.3/lib64/R/bin/Rscript -e "1 + 2"
[1] 3
[vagrant@localhost ropen]$ /opt/microsoft/ropen/4.0.2/lib64/R/bin/Rscript -e "1 + 2"
Microsoft R Open 4.0.2
The enhanced R distribution from Microsoft
Microsoft packages Copyright (C) 2020 Microsoft Corporation

Using the Intel MKL for parallel mathematical computing (using 4 cores).

Default CRAN mirror snapshot taken on 2020-07-16.
See: https://mran.microsoft.com/.

[1] 3
[vagrant@localhost ropen]$ 
```